### PR TITLE
switch back to global XRootD redirector

### DIFF
--- a/src/skim.py
+++ b/src/skim.py
@@ -363,8 +363,8 @@ def run(args):
 
     for file in files:
         if not args.is_local:
-            events_chain.Add(f"root://xrootd-cms.infn.it/{file}")
-            runs_chain.Add(f"root://xrootd-cms.infn.it/{file}")
+            events_chain.Add(f"root://cms-xrd-global.cern.ch/{file}")
+            runs_chain.Add(f"root://cms-xrd-global.cern.ch/{file}")
         else:
             events_chain.Add(file)
             runs_chain.Add(file)


### PR DESCRIPTION
Perhaps it is better to use the global redirector based on latencies.

**root://xrootd-cms.infn.it**:
```
Singularity> ping xrootd-cms.infn.it       
PING xrootd-cms.infn.it(llrxrd-redir.in2p3.fr (2001:660:302c:23:134:158:132:31)) 56 data bytes
64 bytes from llrxrd-redir.in2p3.fr (2001:660:302c:23:134:158:132:31): icmp_seq=1 ttl=54 time=9.29 ms
64 bytes from llrxrd-redir.in2p3.fr (2001:660:302c:23:134:158:132:31): icmp_seq=2 ttl=54 time=9.33 ms
64 bytes from llrxrd-redir.in2p3.fr (2001:660:302c:23:134:158:132:31): icmp_seq=3 ttl=54 time=9.31 ms
```

**root://cms-xrd-global.cern.ch**:
```
Singularity> ping cms-xrd-global.cern.ch       
PING cms-xrd-global.cern.ch(cms-xrd-global01.cern.ch (2001:1458:201:e5::100:49)) 56 data bytes
64 bytes from cms-xrd-global01.cern.ch (2001:1458:201:e5::100:49): icmp_seq=1 ttl=59 time=0.219 ms
64 bytes from cms-xrd-global01.cern.ch (2001:1458:201:e5::100:49): icmp_seq=2 ttl=59 time=0.231 ms
64 bytes from cms-xrd-global01.cern.ch (2001:1458:201:e5::100:49): icmp_seq=3 ttl=59 time=0.204 ms
```