### PR TITLE
update produce_ratio script

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -93,6 +93,8 @@ def parse_arguments():
     ratio_parser.add_argument("--nThreads", type=int, help="Number of threads to be used \
             for multithreading")
     ratio_parser.add_argument("--progress_bar", action="store_true", help="Show progress bar")
+    ratio_parser.add_argument('-hconf', '--hist_config', required=True, type=str, help='Path to the histogram \
+            config file.')
 
     # Produce responses config
     responses_parser = subparsers.add_parser("produce_responses", help="Produce responses \

--- a/src/main.py
+++ b/src/main.py
@@ -80,20 +80,19 @@ def parse_arguments():
     find_range_parser.add_argument("--progress_bar", action="store_true", help="Show progress bar")
 
     # Produce ratio config
-    ratio_parser = subparsers.add_parser("produce_ratio", help="Produce ratio comparisons \
-            for given numerator and denominator files")
-    ratio_parser.add_argument("--numerator", type=str, required=True, help="A root file produced \
-            by dijet_rdf separated by comma")
-    ratio_parser.add_argument("--denominator", type=str, required=True, help="A root file \
-            produced by dijet_rdf separated by comma")
-    ratio_triggers = ratio_parser.add_mutually_exclusive_group()
-    ratio_triggers.add_argument("--triggerlist", type=str, help="Comma separated list of triggers \
-            for which plots will be produced (default value 'all')")
-    ratio_triggers.add_argument("--triggerpath", type=str, help="Path to a file containing a list \
-            of triggers for which plots will be produced")
+    ratio_parser = subparsers.add_parser("produce_ratio", help="Produce Data vs. MC comparisons")
+    ratio_parser.add_argument("--data_file", type=str, required=True, help="A root file \
+            containing skimmed run data")
+    ratio_parser.add_argument("--mc_file", type=str, required=True, help="A root file \
+            containing skimmed MC data")
     ratio_parser.add_argument("--out", type=str, required=True, default="", help="Output path \
             (output file name included)")
     ratio_parser.add_argument("--config", type=str, default="", help="Path to config file")
+    ratio_parser.add_argument("--data_tag", type=str, help="data tag")
+    ratio_parser.add_argument("--mc_tag", type=str, required=True, help="MC tag")
+    ratio_parser.add_argument("--nThreads", type=int, help="Number of threads to be used \
+            for multithreading")
+    ratio_parser.add_argument("--progress_bar", action="store_true", help="Show progress bar")
 
     # Produce responses config
     responses_parser = subparsers.add_parser("produce_responses", help="Produce responses \

--- a/src/skim.py
+++ b/src/skim.py
@@ -429,10 +429,11 @@ def run(args):
             f"J4PSkim_{run_range_str}{args.run_tag}")
 
     print("Writing output")
+    start = time.time()
     events_rdf.Snapshot("Events", output_path+"_events.root", all_columns)
     runs_rdf.Snapshot("Runs", output_path+"_runs.root")
+    print(f"snapshot finished in {time.time()-start} s")
 
-    start = time.time()
     subprocess.run(["hadd", "-f", "-k", output_path+".root",
         output_path+"_events.root", output_path+"_runs.root"])
     os.remove(output_path+"_events.root")


### PR DESCRIPTION
New parser args for `produce_ratio`:
- `data_file`: A root file containing the skimmed run data.
- `mc_file`: A root file containing the skimmed MC data.
- `data_tag`: Tag related to run data used in output file naming (e. g. `egamma`)
- `mc_tag`: Tag related to MC data used in output file naming and reweighing (e. g. `QCD-4Jets_HT-1000to1200_TuneCP5_13p6TeV_madgraphMLM-pythia8`)