### PR TITLE
add cumulative result producer

### DIFF
--- a/src/cumulative.py
+++ b/src/cumulative.py
@@ -1,0 +1,71 @@
+import ROOT
+from processing_utils import file_read_lines, read_config_file, get_bins
+from typing import List
+import argparse, configparser
+import numpy as np
+
+from find_range import find_run_range
+from produce_ratio import produce_ratio
+
+def run(args):
+    # Shut up ROOT
+    ROOT.gErrorIgnoreLevel = ROOT.kWarning
+
+    if args.nThreads:
+        ROOT.EnableImplicitMT(args.nThreads)
+    
+    files: List[str] = []
+    if args.filepaths:
+        paths = [p.strip() for p in args.filepaths.split(",")]
+        for path in paths:
+            files.extend(file_read_lines(path))
+    else:
+        files = [s.strip() for s in args.filelist.split(',')]
+
+    hist_config = read_config_file(args.hist_config)
+
+    if args.groups_of:
+        if args.groups_of > len(files):
+            groups = [files]
+        else:
+            n = args.groups_of
+            groups = [files[n*i:n*i+n] for i in range(int((len(files)+n-1)/n))]
+    else:
+        groups = [files]
+    
+    events_chain = ROOT.TChain("Events")
+    runs_chain = ROOT.TChain("Runs")
+
+    for i, group in enumerate(groups):
+        print(f"Processing {i+1}. group of {len(group)} files")
+        events_chain = ROOT.TChain("Events")
+        runs_chain = ROOT.TChain("Runs")
+
+        for file in group:
+            events_chain.Add(file)
+            runs_chain.Add(file)
+
+        rdf_data = ROOT.RDataFrame(events_chain)
+        rdf_runs = ROOT.RDataFrame(runs_chain)
+        rdf_mc = ROOT.RDataFrame("Events", args.mc_file)
+        if args.progress_bar:
+            ROOT.RDF.Experimental.AddProgressBar(rdf_runs)
+            ROOT.RDF.Experimental.AddProgressBar(rdf_data)
+            ROOT.RDF.Experimental.AddProgressBar(rdf_mc)
+
+        min_run, max_run = find_run_range(rdf_data)
+
+        if args.data_tag:
+            output_path = f"{args.out}/J4PCumulative_runs{min_run}to{max_run}_{args.data_tag}_vs_{args.mc_tag}.root"
+        else:
+            output_path = f"{args.out}/J4PRatio_runs{min_run}to{max_run}_vs_{args.mc_tag}.root"
+   
+        bins = get_bins()
+   
+        file_ratio = ROOT.TFile.Open(f"{output_path}", "RECREATE")
+        for hist in hist_config:
+            if hist.lower() == "default":
+                continue
+            h = produce_ratio(rdf_data, rdf_mc, hist_config[hist], bins)
+            h.Write()
+        file_ratio.Close()

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import argparse
 import ROOT
 
+import cumulative
 import find_json
 import find_newest
 import find_range
@@ -161,6 +162,27 @@ def parse_arguments():
     plots_parser.add_argument("--all", action="store_true",
                                 help="Produce all plots in given .root files")
 
+    # Cumulative results config
+    cum_parser = subparsers.add_parser("cumulative", help="Produce cumulative results for \
+            skimmed data")
+    cum_parser.add_argument("--filelist", type=str, help="Comma separated list of \
+            files produces by the skim script")
+    cum_parser.add_argument('-fp', '--filepaths', type=str, help='Comma separated list of \
+            text files containing input files (one input file per line).')
+    cum_parser.add_argument("--mc_file", type=str, required=True, help="A root file \
+            containing skimmed MC data")
+    cum_parser.add_argument("--out", type=str, required=True, default="", help="Output path \
+            (output file name included)")
+    cum_parser.add_argument("--nThreads", type=int, help="Number of threads to be used \
+            for multithreading")
+    cum_parser.add_argument("--progress_bar", action="store_true", help="Show progress bar")
+    cum_parser.add_argument('-hconf', '--hist_config', required=True, type=str, help="Path to the histogram \
+            config file.")
+    cum_parser.add_argument("--groups_of", type=int, help="Produce cumulative results for \
+            groups containing given number of runs")
+    cum_parser.add_argument("--data_tag", type=str, help="data tag")
+    cum_parser.add_argument("--mc_tag", type=str, required=True, help="MC tag")
+
     # Skimming config
     skim_parser = subparsers.add_parser("skim", help="Perform skimming for\
             given list of input files")
@@ -208,7 +230,9 @@ if __name__ == "__main__":
     
     # One day when Python version >= 3.10.0
     # is used implement match here instead.
-    if command == "find_json":
+    if command == "cumulative":
+        cumulative.run(args)
+    elif command == "find_json":
         find_json.run(args)
     elif command == "find_newest":
         find_newest.run(args)

--- a/src/produce_ratio.py
+++ b/src/produce_ratio.py
@@ -74,6 +74,6 @@ def run(args):
     for hist in hist_config:
         if hist.lower() == "default":
             continue
-        hist = produce_ratio(rdf_data, rdf_mc, hist_config[hist], bins)
-        hist.Write()
+        h = produce_ratio(rdf_data, rdf_mc, hist_config[hist], bins)
+        h.Write()
     file_ratio.Close()


### PR DESCRIPTION
Produces cumulative results for skimmed files. Planned use cases:

- For each channel all skimmed files produced by the automation framework are passed as input files and cumulative results for the whole data is produced
-  For each channel all skimmed files produced by the automation framework are passed as input files and cumulative results are produced for groups of files. The size of a group is determined by the `groups_of` flag. This way we can produce results for e. g. ~10 fb⁻¹ chunks by setting `--groups_of 10` (skimmed input files are ~1 fb⁻¹).

The implementation is currently not producing some important metrics (Mean of MC vs. Data comparison results of single skimmed file vs. integrated luminosity of single skimmed file etc.).