### PR TITLE
Update `produce_ratio` and histogram configs

### DIFF
--- a/data/EGM_histograms.ini
+++ b/data/EGM_histograms.ini
@@ -1,10 +1,145 @@
 [MPF_tag_eta]
 type = Profile1D
 name = MPF_tag_eta
-title = MPF_tag;\eta^\mathrm{tag};<MPF>
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
 x_bins = eta
-x_val = Tag_eta
+x_val = Probe_eta
 y_val = MPF_tag
+
+[MPF_tag_eta_pt50to110]
+type = Profile1D
+name = MPF_tag_eta_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_eta_pt110to230]
+type = Profile1D
+name = MPF_tag_eta_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_eta_pt230]
+type = Profile1D
+name = MPF_tag_eta_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0
+
+[MPF_tag_eta0to1_3_pt50to110]
+type = Profile1D
+name = MPF_tag_eta0to1_3_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) < 1.3
+
+[MPF_tag_eta0to1_3_pt110to230]
+type = Profile1D
+name = MPF_tag_eta0to1_3_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) < 1.3
+
+[MPF_tag_eta0to1_3_pt230]
+type = Profile1D
+name = MPF_tag_eta0to1_3_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0 && abs(Probe_eta) < 1.3
+
+[MPF_tag_eta1_3to2_5_pt50to110]
+type = Profile1D
+name = MPF_tag_eta1_3to2_5_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[MPF_tag_eta1_3to2_5_pt110to230]
+type = Profile1D
+name = MPF_tag_eta1_3to2_5_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[MPF_tag_eta1_3to2_5_pt230]
+type = Profile1D
+name = MPF_tag_eta1_3to2_5_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[MPF_tag_eta2_5to3_0_pt50to110]
+type = Profile1D
+name = MPF_tag_eta2_5to3_0_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[MPF_tag_eta2_5to3_0_pt110to230]
+type = Profile1D
+name = MPF_tag_eta2_5to3_0_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[MPF_tag_eta2_5to3_0_pt230]
+type = Profile1D
+name = MPF_tag_eta2_5to3_0_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[MPF_tag_eta3_0to5_0_pt50to110]
+type = Profile1D
+name = MPF_tag_eta3_0to5_0_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[MPF_tag_eta3_0to5_0_pt110to230]
+type = Profile1D
+name = MPF_tag_eta3_0to5_0_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[MPF_tag_eta3_0to5_0_pt230]
+type = Profile1D
+name = MPF_tag_eta3_0to5_0_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
 
 [MPF_probe_eta]
 type = Profile1D
@@ -13,6 +148,33 @@ title = MPF_probe;\eta^\mathrm{probe};<MPF>
 x_bins = eta
 x_val = Probe_eta
 y_val = MPF_probe
+
+[MPF_probe_eta_pt50to110]
+type = Profile1D
+name = MPF_probe_eta_pt50to110
+title = MPF_probe;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_probe
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_probe_eta_pt110to230]
+type = Profile1D
+name = MPF_probe_eta_pt110to230
+title = MPF_probe;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_probe
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_probe_eta_pt230]
+type = Profile1D
+name = MPF_probe_eta_pt230
+title = MPF_probe;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_probe
+cut = Tag_pt > 230.0
 
 [HDM_tag_eta]
 type = Profile1D
@@ -33,10 +195,145 @@ y_val = HDM_probe
 [DB_direct_eta]
 type = Profile1D
 name = DB_direct_eta
-title = DB_tag;\eta^\mathrm{tag};<DB>
+title = DB_tag;\eta^\mathrm{probe};<DB>
 x_bins = eta
-x_val = Tag_eta
+x_val = Probe_eta
 y_val = DB_direct
+
+[DB_direct_eta_pt50to110]
+type = Profile1D
+name = DB_direct_eta_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_eta_pt110to230]
+type = Profile1D
+name = DB_direct_eta_pt110to230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_eta_pt230]
+type = Profile1D
+name = DB_direct_eta_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0
+
+[DB_direct_eta0to1_3_pt50to110]
+type = Profile1D
+name = DB_direct_eta0to1_3_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) < 1.3
+
+[DB_direct_eta0to1_3_pt110to230]
+type = Profile1D
+name = DB_direct_eta0to1_3_pt110to230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) < 1.3
+
+[DB_direct_eta0to1_3_pt230]
+type = Profile1D
+name = DB_direct_eta0to1_3_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0 && abs(Probe_eta) < 1.3
+
+[DB_direct_eta1_3to2_5_pt50to110]
+type = Profile1D
+name = DB_direct_eta1_3to2_5_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[DB_direct_eta1_3to2_5_pt110to230]
+type = Profile1D
+name = DB_direct_eta1_3to2_5_pt110to230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[DB_direct_eta1_3to2_5_pt230]
+type = Profile1D
+name = DB_direct_eta1_3to2_5_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[DB_direct_eta2_5to3_0_pt50to110]
+type = Profile1D
+name = DB_direct_eta2_5to3_0_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[DB_direct_eta2_5to3_0_pt110to230]
+type = Profile1D
+name = DB_direct_eta2_5to3_0_pt110to250
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[DB_direct_eta2_5to3_0_pt230]
+type = Profile1D
+name = DB_direct_eta2_5to3_0_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[DB_direct_eta3_0to5_0_pt50to110]
+type = Profile1D
+name = DB_direct_eta3_0to5_0_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[DB_direct_eta3_0to5_0_pt110to230]
+type = Profile1D
+name = DB_direct_eta3_0to5_0_pt110to230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[DB_direct_eta3_0to5_0_pt230]
+type = Profile1D
+name = DB_direct_eta3_0to5_0_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
 
 [DB_ratio_eta]
 type = Profile1D
@@ -54,23 +351,176 @@ x_bins = pt
 x_val = Tag_pt
 y_val = MPF_tag
 
-[MPF_tag_pt50]
+[MPF_tag_pt50to110]
 type = Profile1D
-name = MPF_tag_pt50
+name = MPF_tag_pt50to110
 title = MPF_tag;p_{T}^{tag};<MPF>
 x_bins = pt
 x_val = Tag_pt
 y_val = MPF_tag
-x_cut = 50
+cut = Tag_pt > 50.0 && Tag_pt < 110
 
-[MPF_tag_pt110]
+[MPF_tag_pt110to230]
 type = Profile1D
-name = MPF_tag_pt110
+name = MPF_tag_pt110to230
 title = MPF_tag;p_{T}^{tag};<MPF>
 x_bins = pt
 x_val = Tag_pt
 y_val = MPF_tag
-x_cut = 110
+cut = Tag_pt > 110.0 && Tag_pt < 230
+
+[MPF_tag_pt230]
+type = Profile1D
+name = MPF_tag_pt230
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = Tag_pt > 230
+
+[MPF_tag_pt_eta0to1_3]
+type = Profile1D
+name = MPF_tag_pt_eta0to1_3
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[MPF_tag_pt_eta1_3to2_5]
+type = Profile1D
+name = MPF_tag_pt_eta1_3to2_5
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[MPF_tag_pt_eta2_5to3_0]
+type = Profile1D
+name = MPF_tag_pt_eta2_5to3_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[MPF_tag_pt_eta3_0to5_0]
+type = Profile1D
+name = MPF_tag_pt_eta3_0to5_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[MPF_tag_pt50to110_eta0to1_3]
+type = Profile1D
+name = MPF_tag_pt50to110_eta0to1_3
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_pt50to110_eta1_3to2_5]
+type = Profile1D
+name = MPF_tag_pt50to110_eta1_3to2_5
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_pt50to110_eta2_5to3_0]
+type = Profile1D
+name = MPF_tag_pt50to110_eta2_5to3_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_pt50to110_eta3_0to5_0]
+type = Profile1D
+name = MPF_tag_pt50to110_eta3_0to5_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_pt110to230_eta0to1_3]
+type = Profile1D
+name = MPF_tag_pt110to230_eta0to1_3
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_pt110to230_eta1_3to2_5]
+type = Profile1D
+name = MPF_tag_pt110to230_eta1_3to2_5
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_pt110to230_eta2_5to3_0]
+type = Profile1D
+name = MPF_tag_pt110to230_eta2_5to3_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_pt110to230_eta3_0to5_0]
+type = Profile1D
+name = MPF_tag_pt110to230_eta3_0to5_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_pt230_eta0to1_3]
+type = Profile1D
+name = MPF_tag_pt230_eta0to1_3
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 230.0
+
+[MPF_tag_pt230_eta1_3to2_5]
+type = Profile1D
+name = MPF_tag_pt230_eta1_3to2_5
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 230.0
+
+[MPF_tag_pt230_eta2_5to3_0]
+type = Profile1D
+name = MPF_tag_pt230_eta2_5to3_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 230.0
+
+[MPF_tag_pt230_eta3_0to5_0]
+type = Profile1D
+name = MPF_tag_pt230_eta3_0to5_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 230.0
 
 [MPF_probe_pt]
 type = Profile1D
@@ -88,24 +538,6 @@ x_bins = pt
 x_val = Tag_pt
 y_val = HDM_tag
 
-[HDM_tag_pt50]
-type = Profile1D
-name = HDM_tag_pt50
-title = HDM_tag;p_{T}^{tag};<HDM>
-x_bins = pt
-x_val = Tag_pt
-y_val = HDM_tag
-x_cut = 50
-
-[HDM_tag_pt110]
-type = Profile1D
-name = HDM_tag_pt110
-title = HDM_tag;p_{T}^{tag};<HDM>
-x_bins = pt
-x_val = Tag_pt
-y_val = HDM_tag
-x_cut = 110
-
 [HDM_probe_pt]
 type = Profile1D
 name = HDM_probe_pt
@@ -122,23 +554,176 @@ x_bins = pt
 x_val = Tag_pt
 y_val = DB_direct
 
-[DB_direct_pt50]
+[DB_direct_pt50to110]
 type = Profile1D
-name = DB_direct_pt50
+name = DB_direct_pt50to110
 title = DB_tag;p_{T}^{tag};<DB>
 x_bins = pt
 x_val = Tag_pt
 y_val = DB_direct
-x_cut = 50
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
 
-[DB_direct_pt110]
+[DB_direct_pt110to230]
 type = Profile1D
-name = DB_direct_pt110
+name = DB_direct_pt110to230
 title = DB_tag;p_{T}^{tag};<DB>
 x_bins = pt
 x_val = Tag_pt
 y_val = DB_direct
-x_cut = 110
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt230]
+type = Profile1D
+name = DB_direct_pt230
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = Tag_pt > 230.0
+
+[DB_direct_pt_eta0to1_3]
+type = Profile1D
+name = DB_direct_pt_eta0to1_3
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[DB_direct_pt_eta1_3to2_5]
+type = Profile1D
+name = DB_direct_pt_eta1_3to2_5
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[DB_direct_pt_eta2_5to3_0]
+type = Profile1D
+name = DB_direct_pt_eta2_5to3_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[DB_direct_pt_eta3_0to5_0]
+type = Profile1D
+name = DB_direct_pt_eta3_0to5_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[DB_direct_pt50to110_eta0to1_3]
+type = Profile1D
+name = DB_direct_pt50to110_eta0to1_3
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_pt50to110_eta1_3to2_5]
+type = Profile1D
+name = DB_direct_pt50to110_eta1_3to2_5
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_pt50to110_eta2_5to3_0]
+type = Profile1D
+name = DB_direct_pt50to110_eta2_5to3_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_pt50to110_eta3_0to5_0]
+type = Profile1D
+name = DB_direct_pt50to110_eta3_0to5_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_pt110to230_eta0to1_3]
+type = Profile1D
+name = DB_direct_pt110to230_eta0to1_3
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt110to230_eta1_3to2_5]
+type = Profile1D
+name = DB_direct_pt110to230_eta1_3to2_5
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt110to230_eta2_5to3_0]
+type = Profile1D
+name = DB_direct_pt110to230_eta2_5to3_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt110to230_eta3_0to5_0]
+type = Profile1D
+name = DB_direct_pt110to230_eta3_0to5_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt230_eta0to1_3]
+type = Profile1D
+name = DB_direct_pt230_eta0to1_3
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 230.0
+
+[DB_direct_pt230_eta1_3to2_5]
+type = Profile1D
+name = DB_direct_pt230_eta1_3to2_5
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 230.0
+
+[DB_direct_pt230_eta2_5to3_0]
+type = Profile1D
+name = DB_direct_pt230_eta2_5to3_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 230.0
+
+[DB_direct_pt230_eta3_0to5_0]
+type = Profile1D
+name = DB_direct_pt230_eta3_0to5_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 230.0
 
 [DB_ratio_pt]
 type = Profile1D
@@ -148,20 +733,239 @@ x_bins = pt
 x_val = Tag_pt
 y_val = DB_ratio
 
-[DB_ratio_pt50]
+[EFB_chEmHEF_pt]
 type = Profile1D
-name = DB_ratio_pt50
-title = DB_ratio;p_{T}^{tag};<DB>
+name = EFB_chEmHEF_pt
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
 x_bins = pt
 x_val = Tag_pt
-y_val = DB_ratio
-x_cut = 50
+y_val = EFB_chEmHEF
 
-[DB_ratio_pt110]
+[EFB_chEmHEF_pt_eta0to1_3]
 type = Profile1D
-name = DB_ratio_pt110
-title = DB_ratio;p_{T}^{tag};<DB>
+name = EFB_chEmHEF_pt_eta0to1_3
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
 x_bins = pt
 x_val = Tag_pt
-y_val = DB_ratio
-x_cut = 110
+y_val = EFB_chEmHEF
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[EFB_chEmHEF_pt_eta1_3to2_5]
+type = Profile1D
+name = EFB_chEmHEF_pt_eta1_3to2_5
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_chEmHEF
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[EFB_chEmHEF_pt_eta2_5to3_0]
+type = Profile1D
+name = EFB_chEmHEF_pt_eta2_5to3_0
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_chEmHEF
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[EFB_chEmHEF_pt_eta3_0to5_0]
+type = Profile1D
+name = EFB_chEmHEF_pt_eta3_0to5_0
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_chEmHEF
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[EFB_chEmHEF_eta]
+type = Profile1D
+name = EFB_chEmHEF_eta
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_chEmHEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_chEmHEF
+
+[EFB_chEmHEF_eta_pt50to110]
+type = Profile1D
+name = EFB_chEmHEF_eta_pt50to110
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_chEmHEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_chEmHEF
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[EFB_chEmHEF_eta_pt110to230]
+type = Profile1D
+name = EFB_chEmHEF_eta_pt110to230
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_chEmHEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_chEmHEF
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[EFB_chEmHEF_eta_pt230]
+type = Profile1D
+name = EFB_chEmHEF_eta_pt230
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_chEmHEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_chEmHEF
+cut = Tag_pt > 230.0
+
+[EFB_hfEmEF_pt]
+type = Profile1D
+name = EFB_hfEmEF_pt
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+
+[EFB_hfEmEF_pt_eta0to1_3]
+type = Profile1D
+name = EFB_hfEmEF_pt_eta0to1_3
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[EFB_hfEmEF_pt_eta1_3to2_5]
+type = Profile1D
+name = EFB_hfEmEF_pt_eta1_3to2_5
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[EFB_hfEmEF_pt_eta2_5to3_0]
+type = Profile1D
+name = EFB_hfEmEF_pt_eta2_5to3_0
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[EFB_hfEmEF_pt_eta3_0to5_0]
+type = Profile1D
+name = EFB_hfEmEF_pt_eta3_0to5_0
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[EFB_hfEmEF_eta]
+type = Profile1D
+name = EFB_hfEmEF_eta
+title = EFB_hfEmEF;\eta^\mathrm{probe};<EFB_hfEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_hfEmEF
+
+[EFB_hfEmEF_eta_pt50to110]
+type = Profile1D
+name = EFB_hfEmEF_eta_pt50to110
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_hfEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_hfEmEF
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[EFB_hfEmEF_eta_pt110to230]
+type = Profile1D
+name = EFB_hfEmEF_eta_pt110to230
+title = EFB_hfEmEF;\eta^\mathrm{probe};<EFB_hfEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_hfEmEF
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[EFB_hfEmEF_eta_pt230]
+type = Profile1D
+name = EFB_hfEmEF_eta_pt230
+title = EFB_hfEmEF;\eta^\mathrm{probe};<EFB_hfEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_hfEmEF
+cut = Tag_pt > 230.0
+
+[EFB_neEmEF_pt]
+type = Profile1D
+name = EFB_neEmEF_pt
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+
+[EFB_neEmEF_pt_eta0to1_3]
+type = Profile1D
+name = EFB_neEmEF_pt_eta0to1_3
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[EFB_neEmEF_pt_eta1_3to2_5]
+type = Profile1D
+name = EFB_neEmEF_pt_eta1_3to2_5
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[EFB_neEmEF_pt_eta2_5to3_0]
+type = Profile1D
+name = EFB_neEmEF_pt_eta2_5to3_0
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[EFB_neEmEF_pt_eta3_0to5_0]
+type = Profile1D
+name = EFB_neEmEF_pt_eta3_0to5_0
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[EFB_neEmEF_eta]
+type = Profile1D
+name = EFB_neEmEF_eta
+title = EFB_neEmEF;\eta^\mathrm{probe};<EFB_neEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_neEmEF
+
+[EFB_neEmEF_eta_pt50to110]
+type = Profile1D
+name = EFB_neEmEF_eta_pt50to110
+title = EFB_neEmEF;\eta^\mathrm{probe};<EFB_neEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_neEmEF
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[EFB_neEmEF_eta_pt110to230]
+type = Profile1D
+name = EFB_neEmEF_eta_pt110to230
+title = EFB_neEmEF;\eta^\mathrm{probe};<EFB_neEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_neEmEF
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[EFB_neEmEF_eta_pt230]
+type = Profile1D
+name = EFB_neEmEF_eta_pt230
+title = EFB_neEmEF;\eta^\mathrm{probe};<EFB_neEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_neEmEF
+cut = Tag_pt > 230.0

--- a/data/JME_histograms.ini
+++ b/data/JME_histograms.ini
@@ -1,10 +1,145 @@
 [MPF_tag_eta]
 type = Profile1D
 name = MPF_tag_eta
-title = MPF_tag;\eta^\mathrm{tag};<MPF>
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
 x_bins = eta
-x_val = Tag_eta
+x_val = Probe_eta
 y_val = MPF_tag
+
+[MPF_tag_eta_pt50to110]
+type = Profile1D
+name = MPF_tag_eta_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_eta_pt110to230]
+type = Profile1D
+name = MPF_tag_eta_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_eta_pt230]
+type = Profile1D
+name = MPF_tag_eta_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0
+
+[MPF_tag_eta0to1_3_pt50to110]
+type = Profile1D
+name = MPF_tag_eta0to1_3_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) < 1.3
+
+[MPF_tag_eta0to1_3_pt110to230]
+type = Profile1D
+name = MPF_tag_eta0to1_3_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) < 1.3
+
+[MPF_tag_eta0to1_3_pt230]
+type = Profile1D
+name = MPF_tag_eta0to1_3_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0 && abs(Probe_eta) < 1.3
+
+[MPF_tag_eta1_3to2_5_pt50to110]
+type = Profile1D
+name = MPF_tag_eta1_3to2_5_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[MPF_tag_eta1_3to2_5_pt110to230]
+type = Profile1D
+name = MPF_tag_eta1_3to2_5_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[MPF_tag_eta1_3to2_5_pt230]
+type = Profile1D
+name = MPF_tag_eta1_3to2_5_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[MPF_tag_eta2_5to3_0_pt50to110]
+type = Profile1D
+name = MPF_tag_eta2_5to3_0_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[MPF_tag_eta2_5to3_0_pt110to230]
+type = Profile1D
+name = MPF_tag_eta2_5to3_0_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[MPF_tag_eta2_5to3_0_pt230]
+type = Profile1D
+name = MPF_tag_eta2_5to3_0_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[MPF_tag_eta3_0to5_0_pt50to110]
+type = Profile1D
+name = MPF_tag_eta3_0to5_0_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[MPF_tag_eta3_0to5_0_pt110to230]
+type = Profile1D
+name = MPF_tag_eta3_0to5_0_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[MPF_tag_eta3_0to5_0_pt230]
+type = Profile1D
+name = MPF_tag_eta3_0to5_0_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
 
 [MPF_probe_eta]
 type = Profile1D
@@ -13,6 +148,33 @@ title = MPF_probe;\eta^\mathrm{probe};<MPF>
 x_bins = eta
 x_val = Probe_eta
 y_val = MPF_probe
+
+[MPF_probe_eta_pt50to110]
+type = Profile1D
+name = MPF_probe_eta_pt50to110
+title = MPF_probe;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_probe
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_probe_eta_pt110to230]
+type = Profile1D
+name = MPF_probe_eta_pt110to230
+title = MPF_probe;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_probe
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_probe_eta_pt230]
+type = Profile1D
+name = MPF_probe_eta_pt230
+title = MPF_probe;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_probe
+cut = Tag_pt > 230.0
 
 [HDM_tag_eta]
 type = Profile1D
@@ -33,14 +195,149 @@ y_val = HDM_probe
 [DB_direct_eta]
 type = Profile1D
 name = DB_direct_eta
-title = DB_tag;\eta^\mathrm{tag};<DB>
+title = DB_tag;\eta^\mathrm{probe};<DB>
 x_bins = eta
-x_val = Tag_eta
+x_val = Probe_eta
 y_val = DB_direct
+
+[DB_direct_eta_pt50to110]
+type = Profile1D
+name = DB_direct_eta_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_eta_pt110to230]
+type = Profile1D
+name = DB_direct_eta_pt110to230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_eta_pt230]
+type = Profile1D
+name = DB_direct_eta_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0
+
+[DB_direct_eta0to1_3_pt50to110]
+type = Profile1D
+name = DB_direct_eta0to1_3_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) < 1.3
+
+[DB_direct_eta0to1_3_pt110to230]
+type = Profile1D
+name = DB_direct_eta0to1_3_pt110to230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) < 1.3
+
+[DB_direct_eta0to1_3_pt230]
+type = Profile1D
+name = DB_direct_eta0to1_3_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0 && abs(Probe_eta) < 1.3
+
+[DB_direct_eta1_3to2_5_pt50to110]
+type = Profile1D
+name = DB_direct_eta1_3to2_5_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[DB_direct_eta1_3to2_5_pt110to230]
+type = Profile1D
+name = DB_direct_eta1_3to2_5_pt110to230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[DB_direct_eta1_3to2_5_pt230]
+type = Profile1D
+name = DB_direct_eta1_3to2_5_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[DB_direct_eta2_5to3_0_pt50to110]
+type = Profile1D
+name = DB_direct_eta2_5to3_0_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[DB_direct_eta2_5to3_0_pt110to230]
+type = Profile1D
+name = DB_direct_eta2_5to3_0_pt110to250
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[DB_direct_eta2_5to3_0_pt230]
+type = Profile1D
+name = DB_direct_eta2_5to3_0_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[DB_direct_eta3_0to5_0_pt50to110]
+type = Profile1D
+name = DB_direct_eta3_0to5_0_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[DB_direct_eta3_0to5_0_pt110to230]
+type = Profile1D
+name = DB_direct_eta3_0to5_0_pt110to230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[DB_direct_eta3_0to5_0_pt230]
+type = Profile1D
+name = DB_direct_eta3_0to5_0_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
 
 [DB_ratio_eta]
 type = Profile1D
-name = DB_ratio_eta
+name = DB_ratio__eta
 title = DB_ratio;\eta^\mathrm{tag};<DB>
 x_bins = eta
 x_val = Tag_eta
@@ -53,6 +350,177 @@ title = MPF_tag;p_{T}^{tag};<MPF>
 x_bins = pt
 x_val = Tag_pt
 y_val = MPF_tag
+
+[MPF_tag_pt50to110]
+type = Profile1D
+name = MPF_tag_pt50to110
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110
+
+[MPF_tag_pt110to230]
+type = Profile1D
+name = MPF_tag_pt110to230
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230
+
+[MPF_tag_pt230]
+type = Profile1D
+name = MPF_tag_pt230
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = Tag_pt > 230
+
+[MPF_tag_pt_eta0to1_3]
+type = Profile1D
+name = MPF_tag_pt_eta0to1_3
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[MPF_tag_pt_eta1_3to2_5]
+type = Profile1D
+name = MPF_tag_pt_eta1_3to2_5
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[MPF_tag_pt_eta2_5to3_0]
+type = Profile1D
+name = MPF_tag_pt_eta2_5to3_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[MPF_tag_pt_eta3_0to5_0]
+type = Profile1D
+name = MPF_tag_pt_eta3_0to5_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[MPF_tag_pt50to110_eta0to1_3]
+type = Profile1D
+name = MPF_tag_pt50to110_eta0to1_3
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_pt50to110_eta1_3to2_5]
+type = Profile1D
+name = MPF_tag_pt50to110_eta1_3to2_5
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_pt50to110_eta2_5to3_0]
+type = Profile1D
+name = MPF_tag_pt50to110_eta2_5to3_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_pt50to110_eta3_0to5_0]
+type = Profile1D
+name = MPF_tag_pt50to110_eta3_0to5_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_pt110to230_eta0to1_3]
+type = Profile1D
+name = MPF_tag_pt110to230_eta0to1_3
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_pt110to230_eta1_3to2_5]
+type = Profile1D
+name = MPF_tag_pt110to230_eta1_3to2_5
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_pt110to230_eta2_5to3_0]
+type = Profile1D
+name = MPF_tag_pt110to230_eta2_5to3_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_pt110to230_eta3_0to5_0]
+type = Profile1D
+name = MPF_tag_pt110to230_eta3_0to5_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_pt230_eta0to1_3]
+type = Profile1D
+name = MPF_tag_pt230_eta0to1_3
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 230.0
+
+[MPF_tag_pt230_eta1_3to2_5]
+type = Profile1D
+name = MPF_tag_pt230_eta1_3to2_5
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 230.0
+
+[MPF_tag_pt230_eta2_5to3_0]
+type = Profile1D
+name = MPF_tag_pt230_eta2_5to3_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 230.0
+
+[MPF_tag_pt230_eta3_0to5_0]
+type = Profile1D
+name = MPF_tag_pt230_eta3_0to5_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 230.0
 
 [MPF_probe_pt]
 type = Profile1D
@@ -86,6 +554,177 @@ x_bins = pt
 x_val = Tag_pt
 y_val = DB_direct
 
+[DB_direct_pt50to110]
+type = Profile1D
+name = DB_direct_pt50to110
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_pt110to230]
+type = Profile1D
+name = DB_direct_pt110to230
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt230]
+type = Profile1D
+name = DB_direct_pt230
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = Tag_pt > 230.0
+
+[DB_direct_pt_eta0to1_3]
+type = Profile1D
+name = DB_direct_pt_eta0to1_3
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[DB_direct_pt_eta1_3to2_5]
+type = Profile1D
+name = DB_direct_pt_eta1_3to2_5
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[DB_direct_pt_eta2_5to3_0]
+type = Profile1D
+name = DB_direct_pt_eta2_5to3_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[DB_direct_pt_eta3_0to5_0]
+type = Profile1D
+name = DB_direct_pt_eta3_0to5_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[DB_direct_pt50to110_eta0to1_3]
+type = Profile1D
+name = DB_direct_pt50to110_eta0to1_3
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_pt50to110_eta1_3to2_5]
+type = Profile1D
+name = DB_direct_pt50to110_eta1_3to2_5
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_pt50to110_eta2_5to3_0]
+type = Profile1D
+name = DB_direct_pt50to110_eta2_5to3_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_pt50to110_eta3_0to5_0]
+type = Profile1D
+name = DB_direct_pt50to110_eta3_0to5_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_pt110to230_eta0to1_3]
+type = Profile1D
+name = DB_direct_pt110to230_eta0to1_3
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt110to230_eta1_3to2_5]
+type = Profile1D
+name = DB_direct_pt110to230_eta1_3to2_5
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt110to230_eta2_5to3_0]
+type = Profile1D
+name = DB_direct_pt110to230_eta2_5to3_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt110to230_eta3_0to5_0]
+type = Profile1D
+name = DB_direct_pt110to230_eta3_0to5_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt230_eta0to1_3]
+type = Profile1D
+name = DB_direct_pt230_eta0to1_3
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 230.0
+
+[DB_direct_pt230_eta1_3to2_5]
+type = Profile1D
+name = DB_direct_pt230_eta1_3to2_5
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 230.0
+
+[DB_direct_pt230_eta2_5to3_0]
+type = Profile1D
+name = DB_direct_pt230_eta2_5to3_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 230.0
+
+[DB_direct_pt230_eta3_0to5_0]
+type = Profile1D
+name = DB_direct_pt230_eta3_0to5_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 230.0
+
 [DB_ratio_pt]
 type = Profile1D
 name = DB_ratio_pt
@@ -93,3 +732,240 @@ title = DB_ratio;p_{T}^{tag};<DB>
 x_bins = pt
 x_val = Tag_pt
 y_val = DB_ratio
+
+[EFB_chEmHEF_pt]
+type = Profile1D
+name = EFB_chEmHEF_pt
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_chEmHEF
+
+[EFB_chEmHEF_pt_eta0to1_3]
+type = Profile1D
+name = EFB_chEmHEF_pt_eta0to1_3
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_chEmHEF
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[EFB_chEmHEF_pt_eta1_3to2_5]
+type = Profile1D
+name = EFB_chEmHEF_pt_eta1_3to2_5
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_chEmHEF
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[EFB_chEmHEF_pt_eta2_5to3_0]
+type = Profile1D
+name = EFB_chEmHEF_pt_eta2_5to3_0
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_chEmHEF
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[EFB_chEmHEF_pt_eta3_0to5_0]
+type = Profile1D
+name = EFB_chEmHEF_pt_eta3_0to5_0
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_chEmHEF
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[EFB_chEmHEF_eta]
+type = Profile1D
+name = EFB_chEmHEF_eta
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_chEmHEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_chEmHEF
+
+[EFB_chEmHEF_eta_pt50to110]
+type = Profile1D
+name = EFB_chEmHEF_eta_pt50to110
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_chEmHEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_chEmHEF
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[EFB_chEmHEF_eta_pt110to230]
+type = Profile1D
+name = EFB_chEmHEF_eta_pt110to230
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_chEmHEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_chEmHEF
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[EFB_chEmHEF_eta_pt230]
+type = Profile1D
+name = EFB_chEmHEF_eta_pt230
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_chEmHEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_chEmHEF
+cut = Tag_pt > 230.0
+
+[EFB_hfEmEF_pt]
+type = Profile1D
+name = EFB_hfEmEF_pt
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+
+[EFB_hfEmEF_pt_eta0to1_3]
+type = Profile1D
+name = EFB_hfEmEF_pt_eta0to1_3
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[EFB_hfEmEF_pt_eta1_3to2_5]
+type = Profile1D
+name = EFB_hfEmEF_pt_eta1_3to2_5
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[EFB_hfEmEF_pt_eta2_5to3_0]
+type = Profile1D
+name = EFB_hfEmEF_pt_eta2_5to3_0
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[EFB_hfEmEF_pt_eta3_0to5_0]
+type = Profile1D
+name = EFB_hfEmEF_pt_eta3_0to5_0
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[EFB_hfEmEF_eta]
+type = Profile1D
+name = EFB_hfEmEF_eta
+title = EFB_hfEmEF;\eta^\mathrm{probe};<EFB_hfEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_hfEmEF
+
+[EFB_hfEmEF_eta_pt50to110]
+type = Profile1D
+name = EFB_hfEmEF_eta_pt50to110
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_hfEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_hfEmEF
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[EFB_hfEmEF_eta_pt110to230]
+type = Profile1D
+name = EFB_hfEmEF_eta_pt110to230
+title = EFB_hfEmEF;\eta^\mathrm{probe};<EFB_hfEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_hfEmEF
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[EFB_hfEmEF_eta_pt230]
+type = Profile1D
+name = EFB_hfEmEF_eta_pt230
+title = EFB_hfEmEF;\eta^\mathrm{probe};<EFB_hfEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_hfEmEF
+cut = Tag_pt > 230.0
+
+[EFB_neEmEF_pt]
+type = Profile1D
+name = EFB_neEmEF_pt
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+
+[EFB_neEmEF_pt_eta0to1_3]
+type = Profile1D
+name = EFB_neEmEF_pt_eta0to1_3
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[EFB_neEmEF_pt_eta1_3to2_5]
+type = Profile1D
+name = EFB_neEmEF_pt_eta1_3to2_5
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[EFB_neEmEF_pt_eta2_5to3_0]
+type = Profile1D
+name = EFB_neEmEF_pt_eta2_5to3_0
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[EFB_neEmEF_pt_eta3_0to5_0]
+type = Profile1D
+name = EFB_neEmEF_pt_eta3_0to5_0
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[EFB_neEmEF_eta]
+type = Profile1D
+name = EFB_neEmEF_eta
+title = EFB_neEmEF;\eta^\mathrm{probe};<EFB_neEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_neEmEF
+
+[EFB_neEmEF_eta_pt50to110]
+type = Profile1D
+name = EFB_neEmEF_eta_pt50to110
+title = EFB_neEmEF;\eta^\mathrm{probe};<EFB_neEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_neEmEF
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[EFB_neEmEF_eta_pt110to230]
+type = Profile1D
+name = EFB_neEmEF_eta_pt110to230
+title = EFB_neEmEF;\eta^\mathrm{probe};<EFB_neEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_neEmEF
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[EFB_neEmEF_eta_pt230]
+type = Profile1D
+name = EFB_neEmEF_eta_pt230
+title = EFB_neEmEF;\eta^\mathrm{probe};<EFB_neEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_neEmEF
+cut = Tag_pt > 230.0

--- a/data/ZJET_histograms.ini
+++ b/data/ZJET_histograms.ini
@@ -1,10 +1,145 @@
 [MPF_tag_eta]
 type = Profile1D
 name = MPF_tag_eta
-title = MPF_tag;\eta^\mathrm{tag};<MPF>
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
 x_bins = eta
-x_val = Tag_eta
+x_val = Probe_eta
 y_val = MPF_tag
+
+[MPF_tag_eta_pt50to110]
+type = Profile1D
+name = MPF_tag_eta_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_eta_pt110to230]
+type = Profile1D
+name = MPF_tag_eta_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_eta_pt230]
+type = Profile1D
+name = MPF_tag_eta_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0
+
+[MPF_tag_eta0to1_3_pt50to110]
+type = Profile1D
+name = MPF_tag_eta0to1_3_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) < 1.3
+
+[MPF_tag_eta0to1_3_pt110to230]
+type = Profile1D
+name = MPF_tag_eta0to1_3_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) < 1.3
+
+[MPF_tag_eta0to1_3_pt230]
+type = Profile1D
+name = MPF_tag_eta0to1_3_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0 && abs(Probe_eta) < 1.3
+
+[MPF_tag_eta1_3to2_5_pt50to110]
+type = Profile1D
+name = MPF_tag_eta1_3to2_5_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[MPF_tag_eta1_3to2_5_pt110to230]
+type = Profile1D
+name = MPF_tag_eta1_3to2_5_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[MPF_tag_eta1_3to2_5_pt230]
+type = Profile1D
+name = MPF_tag_eta1_3to2_5_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[MPF_tag_eta2_5to3_0_pt50to110]
+type = Profile1D
+name = MPF_tag_eta2_5to3_0_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[MPF_tag_eta2_5to3_0_pt110to230]
+type = Profile1D
+name = MPF_tag_eta2_5to3_0_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[MPF_tag_eta2_5to3_0_pt230]
+type = Profile1D
+name = MPF_tag_eta2_5to3_0_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[MPF_tag_eta3_0to5_0_pt50to110]
+type = Profile1D
+name = MPF_tag_eta3_0to5_0_pt50to110
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[MPF_tag_eta3_0to5_0_pt110to230]
+type = Profile1D
+name = MPF_tag_eta3_0to5_0_pt110to230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[MPF_tag_eta3_0to5_0_pt230]
+type = Profile1D
+name = MPF_tag_eta3_0to5_0_pt230
+title = MPF_tag;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_tag
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
 
 [MPF_probe_eta]
 type = Profile1D
@@ -13,6 +148,33 @@ title = MPF_probe;\eta^\mathrm{probe};<MPF>
 x_bins = eta
 x_val = Probe_eta
 y_val = MPF_probe
+
+[MPF_probe_eta_pt50to110]
+type = Profile1D
+name = MPF_probe_eta_pt50to110
+title = MPF_probe;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_probe
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_probe_eta_pt110to230]
+type = Profile1D
+name = MPF_probe_eta_pt110to230
+title = MPF_probe;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_probe
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_probe_eta_pt230]
+type = Profile1D
+name = MPF_probe_eta_pt230
+title = MPF_probe;\eta^\mathrm{probe};<MPF>
+x_bins = eta
+x_val = Probe_eta
+y_val = MPF_probe
+cut = Tag_pt > 230.0
 
 [HDM_tag_eta]
 type = Profile1D
@@ -33,10 +195,145 @@ y_val = HDM_probe
 [DB_direct_eta]
 type = Profile1D
 name = DB_direct_eta
-title = DB_tag;\eta^\mathrm{tag};<DB>
+title = DB_tag;\eta^\mathrm{probe};<DB>
 x_bins = eta
-x_val = Tag_eta
+x_val = Probe_eta
 y_val = DB_direct
+
+[DB_direct_eta_pt50to110]
+type = Profile1D
+name = DB_direct_eta_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_eta_pt110to230]
+type = Profile1D
+name = DB_direct_eta_pt110to230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_eta_pt230]
+type = Profile1D
+name = DB_direct_eta_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0
+
+[DB_direct_eta0to1_3_pt50to110]
+type = Profile1D
+name = DB_direct_eta0to1_3_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) < 1.3
+
+[DB_direct_eta0to1_3_pt110to230]
+type = Profile1D
+name = DB_direct_eta0to1_3_pt110to230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) < 1.3
+
+[DB_direct_eta0to1_3_pt230]
+type = Profile1D
+name = DB_direct_eta0to1_3_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0 && abs(Probe_eta) < 1.3
+
+[DB_direct_eta1_3to2_5_pt50to110]
+type = Profile1D
+name = DB_direct_eta1_3to2_5_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[DB_direct_eta1_3to2_5_pt110to230]
+type = Profile1D
+name = DB_direct_eta1_3to2_5_pt110to230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[DB_direct_eta1_3to2_5_pt230]
+type = Profile1D
+name = DB_direct_eta1_3to2_5_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[DB_direct_eta2_5to3_0_pt50to110]
+type = Profile1D
+name = DB_direct_eta2_5to3_0_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[DB_direct_eta2_5to3_0_pt110to230]
+type = Profile1D
+name = DB_direct_eta2_5to3_0_pt110to250
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[DB_direct_eta2_5to3_0_pt230]
+type = Profile1D
+name = DB_direct_eta2_5to3_0_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[DB_direct_eta3_0to5_0_pt50to110]
+type = Profile1D
+name = DB_direct_eta3_0to5_0_pt50to110
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 50.0 && Tag_pt < 110.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[DB_direct_eta3_0to5_0_pt110to230]
+type = Profile1D
+name = DB_direct_eta3_0to5_0_pt110to230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 110.0 && Tag_pt < 230.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[DB_direct_eta3_0to5_0_pt230]
+type = Profile1D
+name = DB_direct_eta3_0to5_0_pt230
+title = DB_tag;\eta^\mathrm{probe};<DB>
+x_bins = eta
+x_val = Probe_eta
+y_val = DB_direct
+cut = Tag_pt > 230.0 && abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
 
 [DB_ratio_eta]
 type = Profile1D
@@ -54,23 +351,176 @@ x_bins = pt
 x_val = Tag_pt
 y_val = MPF_tag
 
-[MPF_tag_pt50]
+[MPF_tag_pt50to110]
 type = Profile1D
-name = MPF_tag_pt50
+name = MPF_tag_pt50to110
 title = MPF_tag;p_{T}^{tag};<MPF>
 x_bins = pt
 x_val = Tag_pt
 y_val = MPF_tag
-x_cut = 50
+cut = Tag_pt > 50.0 && Tag_pt < 110
 
-[MPF_tag_pt110]
+[MPF_tag_pt110to230]
 type = Profile1D
-name = MPF_tag_pt110
+name = MPF_tag_pt110to230
 title = MPF_tag;p_{T}^{tag};<MPF>
 x_bins = pt
 x_val = Tag_pt
 y_val = MPF_tag
-x_cut = 110
+cut = Tag_pt > 110.0 && Tag_pt < 230
+
+[MPF_tag_pt230]
+type = Profile1D
+name = MPF_tag_pt230
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = Tag_pt > 230
+
+[MPF_tag_pt_eta0to1_3]
+type = Profile1D
+name = MPF_tag_pt_eta0to1_3
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[MPF_tag_pt_eta1_3to2_5]
+type = Profile1D
+name = MPF_tag_pt_eta1_3to2_5
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[MPF_tag_pt_eta2_5to3_0]
+type = Profile1D
+name = MPF_tag_pt_eta2_5to3_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[MPF_tag_pt_eta3_0to5_0]
+type = Profile1D
+name = MPF_tag_pt_eta3_0to5_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[MPF_tag_pt50to110_eta0to1_3]
+type = Profile1D
+name = MPF_tag_pt50to110_eta0to1_3
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_pt50to110_eta1_3to2_5]
+type = Profile1D
+name = MPF_tag_pt50to110_eta1_3to2_5
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_pt50to110_eta2_5to3_0]
+type = Profile1D
+name = MPF_tag_pt50to110_eta2_5to3_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_pt50to110_eta3_0to5_0]
+type = Profile1D
+name = MPF_tag_pt50to110_eta3_0to5_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[MPF_tag_pt110to230_eta0to1_3]
+type = Profile1D
+name = MPF_tag_pt110to230_eta0to1_3
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_pt110to230_eta1_3to2_5]
+type = Profile1D
+name = MPF_tag_pt110to230_eta1_3to2_5
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_pt110to230_eta2_5to3_0]
+type = Profile1D
+name = MPF_tag_pt110to230_eta2_5to3_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_pt110to230_eta3_0to5_0]
+type = Profile1D
+name = MPF_tag_pt110to230_eta3_0to5_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[MPF_tag_pt230_eta0to1_3]
+type = Profile1D
+name = MPF_tag_pt230_eta0to1_3
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 230.0
+
+[MPF_tag_pt230_eta1_3to2_5]
+type = Profile1D
+name = MPF_tag_pt230_eta1_3to2_5
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 230.0
+
+[MPF_tag_pt230_eta2_5to3_0]
+type = Profile1D
+name = MPF_tag_pt230_eta2_5to3_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 230.0
+
+[MPF_tag_pt230_eta3_0to5_0]
+type = Profile1D
+name = MPF_tag_pt230_eta3_0to5_0
+title = MPF_tag;p_{T}^{tag};<MPF>
+x_bins = pt
+x_val = Tag_pt
+y_val = MPF_tag
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 230.0
 
 [MPF_probe_pt]
 type = Profile1D
@@ -88,24 +538,6 @@ x_bins = pt
 x_val = Tag_pt
 y_val = HDM_tag
 
-[HDM_tag_pt50]
-type = Profile1D
-name = HDM_tag_pt50
-title = HDM_tag;p_{T}^{tag};<HDM>
-x_bins = pt
-x_val = Tag_pt
-y_val = HDM_tag
-x_cut = 50
-
-[HDM_tag_pt110]
-type = Profile1D
-name = HDM_tag_pt110
-title = HDM_tag;p_{T}^{tag};<HDM>
-x_bins = pt
-x_val = Tag_pt
-y_val = HDM_tag
-x_cut = 110
-
 [HDM_probe_pt]
 type = Profile1D
 name = HDM_probe_pt
@@ -122,23 +554,176 @@ x_bins = pt
 x_val = Tag_pt
 y_val = DB_direct
 
-[DB_direct_pt50]
+[DB_direct_pt50to110]
 type = Profile1D
-name = DB_direct_pt50
+name = DB_direct_pt50to110
 title = DB_tag;p_{T}^{tag};<DB>
 x_bins = pt
 x_val = Tag_pt
 y_val = DB_direct
-x_cut = 50
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
 
-[DB_direct_pt110]
+[DB_direct_pt110to230]
 type = Profile1D
-name = DB_direct_pt110
+name = DB_direct_pt110to230
 title = DB_tag;p_{T}^{tag};<DB>
 x_bins = pt
 x_val = Tag_pt
 y_val = DB_direct
-x_cut = 110
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt230]
+type = Profile1D
+name = DB_direct_pt230
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = Tag_pt > 230.0
+
+[DB_direct_pt_eta0to1_3]
+type = Profile1D
+name = DB_direct_pt_eta0to1_3
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[DB_direct_pt_eta1_3to2_5]
+type = Profile1D
+name = DB_direct_pt_eta1_3to2_5
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[DB_direct_pt_eta2_5to3_0]
+type = Profile1D
+name = DB_direct_pt_eta2_5to3_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[DB_direct_pt_eta3_0to5_0]
+type = Profile1D
+name = DB_direct_pt_eta3_0to5_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[DB_direct_pt50to110_eta0to1_3]
+type = Profile1D
+name = DB_direct_pt50to110_eta0to1_3
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_pt50to110_eta1_3to2_5]
+type = Profile1D
+name = DB_direct_pt50to110_eta1_3to2_5
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_pt50to110_eta2_5to3_0]
+type = Profile1D
+name = DB_direct_pt50to110_eta2_5to3_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_pt50to110_eta3_0to5_0]
+type = Profile1D
+name = DB_direct_pt50to110_eta3_0to5_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 50.0 && Tag_pt < 110.0
+
+[DB_direct_pt110to230_eta0to1_3]
+type = Profile1D
+name = DB_direct_pt110to230_eta0to1_3
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt110to230_eta1_3to2_5]
+type = Profile1D
+name = DB_direct_pt110to230_eta1_3to2_5
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt110to230_eta2_5to3_0]
+type = Profile1D
+name = DB_direct_pt110to230_eta2_5to3_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt110to230_eta3_0to5_0]
+type = Profile1D
+name = DB_direct_pt110to230_eta3_0to5_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 110.0 && Tag_pt < 230.0
+
+[DB_direct_pt230_eta0to1_3]
+type = Profile1D
+name = DB_direct_pt230_eta0to1_3
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3 && Tag_pt > 230.0
+
+[DB_direct_pt230_eta1_3to2_5]
+type = Profile1D
+name = DB_direct_pt230_eta1_3to2_5
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5 && Tag_pt > 230.0
+
+[DB_direct_pt230_eta2_5to3_0]
+type = Profile1D
+name = DB_direct_pt230_eta2_5to3_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0 && Tag_pt > 230.0
+
+[DB_direct_pt230_eta3_0to5_0]
+type = Profile1D
+name = DB_direct_pt230_eta3_0to5_0
+title = DB_tag;p_{T}^{tag};<DB>
+x_bins = pt
+x_val = Tag_pt
+y_val = DB_direct
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0 && Tag_pt > 230.0
 
 [DB_ratio_pt]
 type = Profile1D
@@ -148,20 +733,239 @@ x_bins = pt
 x_val = Tag_pt
 y_val = DB_ratio
 
-[DB_ratio_pt50]
+[EFB_chEmHEF_pt]
 type = Profile1D
-name = DB_ratio_pt50
-title = DB_ratio;p_{T}^{tag};<DB>
+name = EFB_chEmHEF_pt
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
 x_bins = pt
 x_val = Tag_pt
-y_val = DB_ratio
-x_cut = 50
+y_val = EFB_chEmHEF
 
-[DB_ratio_pt110]
+[EFB_chEmHEF_pt_eta0to1_3]
 type = Profile1D
-name = DB_ratio_pt110
-title = DB_ratio;p_{T}^{tag};<DB>
+name = EFB_chEmHEF_pt_eta0to1_3
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
 x_bins = pt
 x_val = Tag_pt
-y_val = DB_ratio
-x_cut = 110
+y_val = EFB_chEmHEF
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[EFB_chEmHEF_pt_eta1_3to2_5]
+type = Profile1D
+name = EFB_chEmHEF_pt_eta1_3to2_5
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_chEmHEF
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[EFB_chEmHEF_pt_eta2_5to3_0]
+type = Profile1D
+name = EFB_chEmHEF_pt_eta2_5to3_0
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_chEmHEF
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[EFB_chEmHEF_pt_eta3_0to5_0]
+type = Profile1D
+name = EFB_chEmHEF_pt_eta3_0to5_0
+title = EFB_chEmHEF;p_{T}^{tag};<EFB_chEmHEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_chEmHEF
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[EFB_chEmHEF_eta]
+type = Profile1D
+name = EFB_chEmHEF_eta
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_chEmHEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_chEmHEF
+
+[EFB_chEmHEF_eta_pt50to110]
+type = Profile1D
+name = EFB_chEmHEF_eta_pt50to110
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_chEmHEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_chEmHEF
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[EFB_chEmHEF_eta_pt110to230]
+type = Profile1D
+name = EFB_chEmHEF_eta_pt110to230
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_chEmHEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_chEmHEF
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[EFB_chEmHEF_eta_pt230]
+type = Profile1D
+name = EFB_chEmHEF_eta_pt230
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_chEmHEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_chEmHEF
+cut = Tag_pt > 230.0
+
+[EFB_hfEmEF_pt]
+type = Profile1D
+name = EFB_hfEmEF_pt
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+
+[EFB_hfEmEF_pt_eta0to1_3]
+type = Profile1D
+name = EFB_hfEmEF_pt_eta0to1_3
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[EFB_hfEmEF_pt_eta1_3to2_5]
+type = Profile1D
+name = EFB_hfEmEF_pt_eta1_3to2_5
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[EFB_hfEmEF_pt_eta2_5to3_0]
+type = Profile1D
+name = EFB_hfEmEF_pt_eta2_5to3_0
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[EFB_hfEmEF_pt_eta3_0to5_0]
+type = Profile1D
+name = EFB_hfEmEF_pt_eta3_0to5_0
+title = EFB_hfEmEF;p_{T}^{tag};<EFB_hfEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_hfEmEF
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[EFB_hfEmEF_eta]
+type = Profile1D
+name = EFB_hfEmEF_eta
+title = EFB_hfEmEF;\eta^\mathrm{probe};<EFB_hfEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_hfEmEF
+
+[EFB_hfEmEF_eta_pt50to110]
+type = Profile1D
+name = EFB_hfEmEF_eta_pt50to110
+title = EFB_chEmHEF;\eta^\mathrm{probe};<EFB_hfEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_hfEmEF
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[EFB_hfEmEF_eta_pt110to230]
+type = Profile1D
+name = EFB_hfEmEF_eta_pt110to230
+title = EFB_hfEmEF;\eta^\mathrm{probe};<EFB_hfEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_hfEmEF
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[EFB_hfEmEF_eta_pt230]
+type = Profile1D
+name = EFB_hfEmEF_eta_pt230
+title = EFB_hfEmEF;\eta^\mathrm{probe};<EFB_hfEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_hfEmEF
+cut = Tag_pt > 230.0
+
+[EFB_neEmEF_pt]
+type = Profile1D
+name = EFB_neEmEF_pt
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+
+[EFB_neEmEF_pt_eta0to1_3]
+type = Profile1D
+name = EFB_neEmEF_pt_eta0to1_3
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+cut = abs(Probe_eta) > 0.0 && abs(Probe_eta) < 1.3
+
+[EFB_neEmEF_pt_eta1_3to2_5]
+type = Profile1D
+name = EFB_neEmEF_pt_eta1_3to2_5
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+cut = abs(Probe_eta) > 1.3 && abs(Probe_eta) < 2.5
+
+[EFB_neEmEF_pt_eta2_5to3_0]
+type = Profile1D
+name = EFB_neEmEF_pt_eta2_5to3_0
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+cut = abs(Probe_eta) > 2.5 && abs(Probe_eta) < 3.0
+
+[EFB_neEmEF_pt_eta3_0to5_0]
+type = Profile1D
+name = EFB_neEmEF_pt_eta3_0to5_0
+title = EFB_neEmEF;p_{T}^{tag};<EFB_neEmEF>
+x_bins = pt
+x_val = Tag_pt
+y_val = EFB_neEmEF
+cut = abs(Probe_eta) > 3.0 && abs(Probe_eta) < 5.0
+
+[EFB_neEmEF_eta]
+type = Profile1D
+name = EFB_neEmEF_eta
+title = EFB_neEmEF;\eta^\mathrm{probe};<EFB_neEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_neEmEF
+
+[EFB_neEmEF_eta_pt50to110]
+type = Profile1D
+name = EFB_neEmEF_eta_pt50to110
+title = EFB_neEmEF;\eta^\mathrm{probe};<EFB_neEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_neEmEF
+cut = Tag_pt > 50.0 && Tag_pt < 110.0
+
+[EFB_neEmEF_eta_pt110to230]
+type = Profile1D
+name = EFB_neEmEF_eta_pt110to230
+title = EFB_neEmEF;\eta^\mathrm{probe};<EFB_neEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_neEmEF
+cut = Tag_pt > 110.0 && Tag_pt < 230.0
+
+[EFB_neEmEF_eta_pt230]
+type = Profile1D
+name = EFB_neEmEF_eta_pt230
+title = EFB_neEmEF;\eta^\mathrm{probe};<EFB_neEmEF>
+x_bins = eta
+x_val = Probe_eta
+y_val = EFB_neEmEF
+cut = Tag_pt > 230.0


### PR DESCRIPTION
Histogram configs now contains different combinations of pt and eta cuts.

Time evolution output produced by `produce_ratio` now contains `min_run` and `max_run` as a function of cumulative luminosity (needed when including eras in result plots).